### PR TITLE
Make package.sh shell use more portable

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 
 FILENAME="bolt_1.4.4"


### PR DESCRIPTION
Change package.sh to specifically use BASH as the shell as newer Debian and OSX default to use a 100% POSIX shell that doesn't support `[[ ]]` for pattern matching, whereas BASH, KSH anD ZSH do and BASH is available on OSX and all Linux distributions (notably Fedora, CentOS, RHEL, Debian & Ubuntu).
