### PR TITLE
Fixed bolt issue #1768

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -16,7 +16,7 @@ git checkout master
 # If no parameter is passed to the script package the tagged version
 if [[ $1 = "" ]] ; then
     echo Doing checkout of version tagged: v$VERSION
-    git checkout -q v$VERSION 
+    git checkout -q v$VERSION
     FILENAME="bolt_$VERSION"
 else
     # If the parameter 'master' is passed, we already have it, else a commit ID
@@ -82,6 +82,9 @@ cp extras/.htaccess bolt/vendor/.htaccess
 if [[ -f "./custom.sh" ]] ; then
     custom_pre_archive
 fi
+
+# fix bolt issue 1768: make the tars behave more unix-like
+tar czf $FILENAME.tar.gz bolt/
 
 # Make the archives..
 cd bolt


### PR DESCRIPTION
Fix bolt issue 1768.

To allow for deploy scripts to keep working correctly, I've chosen to create the 'unix-like' tar to have an extension of .tar.gz and leave the old 'windows-like' tar in place, with an extension of .tgz.
