### PR TITLE
Ensure guzzle/guzzle ~3.9 is added back to the build for PHP 5.3 sites

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -55,6 +55,7 @@ fi
 
 # Update Composer iteslf and any required packages
 php composer.phar self-update
+php composer.phar require --no-update guzzle/guzzle ~3.9
 php composer.phar update --no-dev --optimize-autoloader
 
 rm -rf $BUILDDIR


### PR DESCRIPTION
Goes hand-in-hand with https://github.com/bolt/bolt/pull/3305